### PR TITLE
Add Pie method signature.

### DIFF
--- a/app/src/main/java/io/noisyfox/oplongshotxposed/XposedInit.java
+++ b/app/src/main/java/io/noisyfox/oplongshotxposed/XposedInit.java
@@ -43,7 +43,7 @@ public class XposedInit implements IXposedHookLoadPackage {
                     Context.class,
                     "com.oneplus.screenshot.SaveImageInBackgroundData",
                     NotificationManager.class,
-		    boolean.class
+                    boolean.class
             }
     };
 

--- a/app/src/main/java/io/noisyfox/oplongshotxposed/XposedInit.java
+++ b/app/src/main/java/io/noisyfox/oplongshotxposed/XposedInit.java
@@ -38,6 +38,12 @@ public class XposedInit implements IXposedHookLoadPackage {
                     Context.class,
                     "com.oneplus.screenshot.SaveImageInBackgroundData",
                     NotificationManager.class
+            },
+            { // OOS based on android 9.0
+                    Context.class,
+                    "com.oneplus.screenshot.SaveImageInBackgroundData",
+                    NotificationManager.class,
+		    boolean.class
             }
     };
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,7 +49,7 @@
         android:layout_marginTop="20dp"
         android:autoLink="all"
         android:gravity="right"
-        android:text="by Noisyfox"
+        android:text="by Noisyfox, Pie patches by Fif_ on XDA."
         android:textSize="15sp" />
 
     <Space


### PR DESCRIPTION
Android Pie has a different method signature for the
com.oneplus.screenshot.SaveImageInBackgroundTask constructor.